### PR TITLE
Fixed bug in the docs editor-terminal was written as terminal-editor

### DIFF
--- a/html/scenarios/layouts.hbs
+++ b/html/scenarios/layouts.hbs
@@ -24,8 +24,8 @@
                         <td><a href="/courses/docker-orchestration/getting-started-with-swarm-mode" target="_blank">Link</a></td>
                     </tr>
                     <tr>
-                        <td>Terminal + Editor</td>
-                        <td>terminal-editor</td>
+                        <td>Editor + Terminal</td>
+                        <td>editor-terminal</td>
                         <td><a href="/courses/docker/create-nginx-static-web-server" target="_blank">Link</a></td>
                     </tr>
                 </tbody>


### PR DESCRIPTION
Minor update to the documentation for the layouts, the syntax for Terminal and Editor was the wrong way round.